### PR TITLE
feat: Separate host and build context in ci

### DIFF
--- a/.github/actions/setup_conan/action.yml
+++ b/.github/actions/setup_conan/action.yml
@@ -23,9 +23,12 @@ outputs:
   home:
     description: "The conan home path"
     value: ${{ steps.output.outputs.home }}
-  profile: # FIXME: Separate host and build profile to allow ci for compile compilation
-    description: "The conan profile to be used"
-    value: ${{ steps.output.outputs.profile }}
+  host_profile:
+    description: "The conan host profile to be used"
+    value: ${{ steps.output.outputs.host_profile }}
+  build_profile:
+    description: "The conan build profile to be used"
+    value: ${{ steps.output.outputs.build_profile }}
   args:
     description: "The corresponding args that should be used in conan commands afterwards"
     value: ${{ steps.output.outputs.args }}
@@ -37,6 +40,11 @@ runs:
       shell: bash
       run: |
         pip3 install conan
+
+    - name: Detect conan default profile (used as build profile afterwards)
+      shell: bash
+      run: |
+        conan profile detect
 
     - name: Parse os and os version
       id: parse_os
@@ -66,11 +74,12 @@ runs:
       id: output
       shell: bash
       run: |
-        export PROFILE=$(python3 script/match_conan_profile.py "${{ steps.parse_os.outputs.name }}-${{ steps.parse_os.outputs.version }}-${{ inputs.arch }}-${{ steps.parse_compiler.outputs.name }}-${{ steps.parse_compiler.outputs.version }}-${{ inputs.build_type }}")
+        export HOST_PROFILE=$(python3 script/match_conan_profile.py "${{ steps.parse_os.outputs.name }}-${{ steps.parse_os.outputs.version }}-${{ inputs.arch }}-${{ steps.parse_compiler.outputs.name }}-${{ steps.parse_compiler.outputs.version }}-${{ inputs.build_type }}")
+        export BUILD_PROFILE=default
         echo "home=$(conan config home)" >> "$GITHUB_OUTPUT"
-        # FIXME: Separate host and build profile to allow ci for compile compilation
-        echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
-        echo "args=-pr:a '$PROFILE' -s:b 'build_type=Release' -s:h 'build_type=${{ inputs.build_type }}' ${{ inputs.args }}" >> "$GITHUB_OUTPUT"
+        echo "host_profile=$HOST_PROFILE" >> "$GITHUB_OUTPUT"
+        echo "build_profile=$BUILD_PROFILE" >> "$GITHUB_OUTPUT"
+        echo "args=-pr:b '$BUILD_PROFILE' -pr:h '$HOST_PROFILE' -s:h 'build_type=${{ inputs.build_type }}' ${{ inputs.args }}" >> "$GITHUB_OUTPUT"
 
     - name: Install conan config folder
       shell: bash


### PR DESCRIPTION
This allows cross-compilation ci test.

Currently only support customization on host profile; for build context, it simply uses the `default` profile. Since this action supports an `args` string input, one may customize the build context somehow using it for now.

The reason why I don't support customization on build profile directly is that this implies creating another github action named `match_conan_profile`, which finds the most matched profile for the inputs and then outputs the profile. But there's no easy solution to inject build_type into that profile. The possible solutions are:

- create profiles named `build_type-<build_type>`, make the `match_conan_profile` action outputs both `<matched_profile>` and `build_type-<build_type>`, then users can invoke it by `-pr:h <matched_profile> -pr:h build_type-<build_type>` - but what about other settings, should I create and output even more profiles?
- Specify the <build_type> section of conan profile naming explicitly. This allows profiles to contain a setting `build_type=<build_type>`, so in the action we can simply match the corresponding profile respectively. However, the <build_type> section is not to distinguish between host and build context. Instead, it indicates which <build_type> the build context is.
- Add a <context> section to conan profile naming or create different folders for host context and build context. This could be done, but makes the management of conan profiles more complex.

As a result, I choose to detect a `default` profile and use that profile for build context. This won't cause a big problem as build context is only used to build tools like cmake, ninja and so on.